### PR TITLE
Add support for save/update with nested paths

### DIFF
--- a/src/DefaultModelMethods.js
+++ b/src/DefaultModelMethods.js
@@ -94,7 +94,16 @@ class DefaultModelMethods {
 
 		this.schema.eachPath((pathname) => {
 			if (data[pathname] !== undefined) {
-				doc[pathname] = data[pathname];
+				if (pathname.includes('.')) {
+					// nested document
+					const keys = pathname.split('.');
+					const lastKey = keys.pop();
+					const lastObj = keys.reduce((doc, key) =>
+						doc[key] = doc[key] || {}, doc)
+					lastObj[lastKey] = data[pathname];
+				} else {
+					doc[pathname] = data[pathname];
+				}
 			}
 		});
 
@@ -196,10 +205,27 @@ class DefaultModelMethods {
 	async apiPut(data) {
 		//// this points to document (schema.methods.)
 		this.schema.eachPath((pathname) => {
+			let newValue = undefined;
+			let isChanged = false;
 			if (data[pathname] !== undefined) {
-				this[pathname] = data[pathname];
+				newValue = data[pathname];
+				isChanged = true;
 			} else if (data[pathname] === null) {
-				this[pathname] = undefined;
+				newValue = undefined;
+				isChanged = true;
+			}
+			if (isChanged) {
+				if (pathname.includes('.')) {
+					let doc = this;
+					// nested document
+					const keys = pathname.split('.');
+					const lastKey = keys.pop();
+					const lastObj = keys.reduce((doc, key ) =>
+						doc[key] = doc[key] || {},	doc)
+					lastObj[lastKey] = newValue;
+				} else {
+					this[pathname] = newValue;
+				}
 			}
 		});
 


### PR DESCRIPTION
Patch to save/update documents with nested paths like

`{ _id: '....', nested: {key1: val1, key2: val2, ...} ...`

Works for whatever depth in path like

`... nested: { nested1: { nested2 : { key1: val1 } } } ...`

To save/update use `...nested.key1=newVal1&nested.key2=newVal2...` or `...nested.nested1.nested2.key1=newVal1...` in POST/PUT.

I was not able to create a test because tests for current module fails for [this problem](https://github.com/npm/libnpmdiff/issues/4) which I don't know how to solve (sorry I'm new to npm/nodejs)